### PR TITLE
fix: generate ref node in import

### DIFF
--- a/src/main/java/org/yinwang/pysonar/ast/Import.java
+++ b/src/main/java/org/yinwang/pysonar/ast/Import.java
@@ -30,7 +30,9 @@ public class Import extends Node {
                 Analyzer.self.putProblem(this, "Cannot load module");
             } else if (a.asname != null) {
                 s.insert(a.asname.id, a.asname, mod, Binding.Kind.VARIABLE);
+                transformExpr(a.asname, s);
             }
+            transformExpr(a.name.get(0), s);
         }
         return Type.CONT;
     }

--- a/src/main/java/org/yinwang/pysonar/ast/Import.java
+++ b/src/main/java/org/yinwang/pysonar/ast/Import.java
@@ -32,7 +32,9 @@ public class Import extends Node {
                 s.insert(a.asname.id, a.asname, mod, Binding.Kind.VARIABLE);
                 transformExpr(a.asname, s);
             }
-            transformExpr(a.name.get(0), s);
+            if (!a.name.isEmpty()) {
+                transformExpr(a.name.get(0), s);
+            }
         }
         return Type.CONT;
     }


### PR DESCRIPTION
For code like:

``` python
import lib as L
```

We will generate ref node for `L` and `lib`. Is this good? 
